### PR TITLE
Обновить e11y до 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "npm run editorconfig"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^0.11.1",
+    "@11ty/eleventy": "^0.12.1",
     "autoprefixer": "^10.2.5",
     "gulp": "^4.0.2",
     "gulp-esbuild": "^0.6.0",


### PR DESCRIPTION
Правит уязвимость pug из вкладки "Security". 

В самом обновлении кроме этого фикса есть только прекращение поддержки восьмой ноды