### PR TITLE
Добавляет автогенерацию симлинков в Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,8 @@ WORKDIR /platform
 COPY . .
 
 RUN npm install \
-&& ln -sf ../content/css src/css \
-&& ln -sf ../content/js src/js \
-&& ln -sf ../content/html src/html
+&& for dir in `ls ./content/ | grep -v "docs" | grep -v "\.."`\
+ ; do `ln -sf "content/$dir" "src/$fir"` ; done
 
 VOLUME /platform/content
 EXPOSE 8080


### PR DESCRIPTION
Уже не на первой dev встрече был поднят вопрос о том, что платформа должна иметь возможность поддерживать не только "родную" Доку, но и Доку для других. Мысль в голове засела, что можно было бы добавить чуточку автоматизации к скрипту, в котором мы указываем набор папок. Я сделал генерацию симлинков для папок, кроме папки docs и файлов. Что скажите? Нужно ли это?

Ну и проверить я смог это на Mac и в контейнере Linux. Надо бы проверить решение на других платформах, если оно вообще нужно. Также можно заменить простой строчкой скрипт make-links.js. Может быть это будет более простым решением, но не знаю нужно ли и это.

@nlopin @pepelsbey @furtivite @solarrust 