### PR TITLE
Поднимает требуемую версию npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT + CC BY-NC-SA 4.0",
   "engines": {
     "node": "14.x",
-    "npm": "6.x"
+    "npm": "7.x"
   },
   "browserslist": [
     "last 2 version",


### PR DESCRIPTION
Раз у нас везде про v7.x написано и лок-файл v2.