### PR TITLE
Добавляет 404 страницу

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,7 +22,7 @@ module.exports = function(config) {
     )
   })
 
-  // 404
+  // 404 for local build
   config.setBrowserSyncConfig({
     callbacks: {
       ready: function(err, bs) {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,23 +22,6 @@ module.exports = function(config) {
     )
   })
 
-  // 404 for local build
-  config.setBrowserSyncConfig({
-    callbacks: {
-      ready: function(err, bs) {
-
-        bs.addMiddleware("*", (req, res) => {
-          const content_404 = fs.readFileSync('dist/404/index.html');
-          // Add 404 http status code in request header.
-          res.writeHead(404, { "Content-Type": "text/html; charset=UTF-8" });
-          // Provides the 404 content without redirect.
-          res.write(content_404);
-          res.end();
-        });
-      }
-    }
-  });
-
   config.addFilter('ruDate', (value) => {
     return value.toLocaleString('ru', {
       year: 'numeric',

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 const htmlmin = require('html-minifier')
+const fs = require("fs")
 const { mainSections } = require("./config/constants.js")
 
 module.exports = function(config) {
@@ -20,6 +21,23 @@ module.exports = function(config) {
       collectionApi.getFilteredByGlob(`src/${section}/doka/**/index.md`)
     )
   })
+
+  // 404
+  config.setBrowserSyncConfig({
+    callbacks: {
+      ready: function(err, bs) {
+
+        bs.addMiddleware("*", (req, res) => {
+          const content_404 = fs.readFileSync('dist/404/index.html');
+          // Add 404 http status code in request header.
+          res.writeHead(404, { "Content-Type": "text/html; charset=UTF-8" });
+          // Provides the 404 content without redirect.
+          res.write(content_404);
+          res.end();
+        });
+      }
+    }
+  });
 
   config.addFilter('ruDate', (value) => {
     return value.toLocaleString('ru', {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,4 @@
 const htmlmin = require('html-minifier')
-const fs = require("fs")
 const { mainSections } = require("./config/constants.js")
 
 module.exports = function(config) {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,25 @@
+[build]
+    command = "npm run build"
+    publish = "dist"
+
+[context.production.environment]
+    ELEVENTY_ENV = "production"
+
+[[headers]]
+    for = "/*"
+    [headers.values]
+        X-Frame-Options = "SAMEORIGIN"
+        X-XSS-Protection = "1; mode=block"
+        X-Content-Type-Options = "nosniff"
+        Referrer-Policy= "no-referrer-when-downgrade"
+
+# [[redirects]]
+#     from = "https://eleventastic.netlify.com/*"
+#     to = "https://eleventastic.dev/:splat"
+#     status = 301
+#     force = true
+
+[[redirects]]
+    from = "*"
+    to = "/404"
+    status = 404

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,12 +13,6 @@
         X-Content-Type-Options = "nosniff"
         Referrer-Policy= "no-referrer-when-downgrade"
 
-# [[redirects]]
-#     from = "https://eleventastic.netlify.com/*"
-#     to = "https://eleventastic.dev/:splat"
-#     status = 301
-#     force = true
-
 [[redirects]]
     from = "*"
     to = "/404"

--- a/src/pages/404.njk
+++ b/src/pages/404.njk
@@ -3,3 +3,7 @@ title: Страница не найдена
 layout: base.njk
 permalink: 404/index.html
 ---
+<div class="not-found">
+  {{ title }}
+  <p><a href="/">Вернись на главную</a></p>
+</div>

--- a/src/pages/404.njk
+++ b/src/pages/404.njk
@@ -3,7 +3,6 @@ title: Страница не найдена
 layout: base.njk
 permalink: 404/index.html
 ---
-<div class="not-found">
-  {{ title }}
-  <p><a href="/">Вернись на главную</a></p>
-</div>
+
+<h1>{{ title }}</h1>
+<p><a href="/">Вернуться на главную</a></p>


### PR DESCRIPTION
- Добавляет 404 страницу на виртуальном сервере ([инструкция](https://www.11ty.dev/docs/quicktips/not-found/#with-serve))
- Переносит `netlify.toml`, который будет делать 404 страницу на стороне провайдера.