### PR TITLE
Правит вывод авторов

### DIFF
--- a/src/includes/contributors.njk
+++ b/src/includes/contributors.njk
@@ -1,5 +1,12 @@
 <section class="contributors">
-  <p>Автор: {{ author }}</p>
+  <p>Авторы: </p>
+  <ul>
+      {% for author in authors %}
+        <li>
+          {{ author }}
+        </li>
+      {% endfor %}
+  </ul>
   {% if contributors %}
     <details>
       <summary>Свой вклад внесли</summary>


### PR DESCRIPTION
В [issue #352 репозитория контента](https://github.com/Y-Doka/content/issues/352) поставлена задача выводить авторов и редакторов не строкой, а массивом. Правит вывод «отмассированного» контента